### PR TITLE
fixed ctes for order_calculations and added in dbt utls

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 
-name: amy_trainingproject
+name: 'amy_trainingproject'
 version: '1.0'
 profile: amy_trainingproject
 source-paths: ["models"]

--- a/models/marts/order_calculations.sql
+++ b/models/marts/order_calculations.sql
@@ -1,23 +1,27 @@
-with customer_reorders as (
-        
+with data_source as (
+    
+    select * from {{ref('fct_order_items')}}
+),
+
+lagged_source as (
+    
     select
         order_id,
         customer_id,
         order_date,
         lag (order_date) over (partition by customer_id order by customer_id, order_date) as previous_order_date
-    from {{ref('fct_order_items')}}
-                
+    from data_source
 ),
 
-renamed as (
-
+order_calculations as (
+    
     select
         customer_id,
         datediff(month, previous_order_date, order_date) as months_since_prior_order
+    from lagged_source
         
-    from customer_reorders
- )
- 
+)
+
     select 
         *
-    from renamed 
+    from order_calculations

--- a/models/marts/ranking.sql
+++ b/models/marts/ranking.sql
@@ -1,0 +1,21 @@
+with ranked as(
+
+select *,
+  dense_rank() over 
+  (partition by customer_id
+  order by order_id) as order_num --row_number will number the rows, using rank( would be just more random?, use row number to fix duplication
+ from dbt_achen.fct_order_items
+ 
+)
+
+select
+    customer_id,
+{% for order in [1,2,3] %}
+    sum(case when order_num = {{order}}
+           then item_price 
+           else 0 end) as order_{{order}}_total
+           {{"," if not loop.last}}
+  {% endfor %}
+  from ranked
+  group by 1
+  

--- a/models/staging/stg_customers.sql
+++ b/models/staging/stg_customers.sql
@@ -14,12 +14,16 @@ stg_customers as (
        first_name,        
        last_name,        
        gender,
+       {{ dbt_utils.surrogate_key('id', 'created_at') }} as unique_id,
        
        --marketing            
        accepts_marketing,
        
        --dates
-       created_at 
+       created_at
+       
+       
+       
         
         
      from source

--- a/models/staging/stg_orders.sql
+++ b/models/staging/stg_orders.sql
@@ -1,8 +1,3 @@
-{{
-    config(
-        schema='staging'
-    )
-}}
 with source as (
 
     select * from {{ ref('orders_upload') }}

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+    - git: https://github.com/fishtown-analytics/dbt-utils
+      revision: 0.1.21


### PR DESCRIPTION
Broke apart the CTEs rather than one for the lag and date diff

```
with data_source as (
    
    select * from {{ref('fct_order_items')}}
),

lagged_source as (
    
    select
        order_id,
        customer_id,
        order_date,
        lag (order_date) over (partition by customer_id order by customer_id, order_date) as previous_order_date
    from data_source
),

order_calculations as (
    
    select
        customer_id,
        datediff(month, previous_order_date, order_date) as months_since_prior_order
    from lagged_source
        
)

    select 
        *
    from order_calculations
```

Updated the stg_customers model with a dbt utils command and also added the package 

`{{ dbt_utils.surrogate_key('id', 'created_at') }} as unique_id,`